### PR TITLE
fix: remove unnecessary 'false' arg in polylrscheduler super method

### DIFF
--- a/multitalent/training/lr_scheduler/polylr.py
+++ b/multitalent/training/lr_scheduler/polylr.py
@@ -8,7 +8,7 @@ class PolyLRScheduler(_LRScheduler):
         self.max_steps = max_steps
         self.exponent = exponent
         self.ctr = 0
-        super().__init__(optimizer, current_step if current_step is not None else -1, False)
+        super().__init__(optimizer, current_step if current_step is not None else -1)
 
     def step(self, current_step=None):
         if current_step is None or current_step == -1:


### PR DESCRIPTION
This was causing too many additional args error.